### PR TITLE
feat: シリアルコード入力でアプリ内専用音声を解放する機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,123 @@
-# Tauri + React + Typescript
+# いなりといっしょ！ (RakushiTimer)
 
-This template should help get you started developing with Tauri, React and Typescript in Vite.
+Vライバー「楽下いなり」の声でアラームを鳴らす Android アプリ。
+Tauri v2 + React + TypeScript で構築。
 
-## Recommended IDE Setup
+## 開発環境
 
 - [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+- Node.js + pnpm
+- Rust (Android ターゲット含む)
+
+```bash
+pnpm install
+pnpm tauri android dev
+```
+
+## テスト
+
+```bash
+pnpm test --run       # フロントエンドテスト
+cargo test            # Rustテスト（src-tauri/ 内で実行）
+```
+
+---
+
+## シリアルコードで音声をアンロックする仕組み
+
+ユーザーがシリアルコードを入力すると、アプリにバンドルされた専用音声がアンロックされ、アラーム音として選択できるようになる機能。
+
+### 設計概要
+
+| 項目 | 内容 |
+|------|------|
+| 検証方式 | クライアントサイドのみ（SHA-256ハッシュ比較） |
+| 音声配置 | アプリにバンドル（`src-tauri/sounds/`） |
+| 状態保存 | `tauri-plugin-store`（アンロック済みIDをローカルに永続化） |
+| 対応 | 1シリアルコード = 1音声 |
+
+### 新しい音声を追加する手順
+
+#### 1. 音声ファイルを配置
+
+```
+src-tauri/sounds/your-sound.mp3
+```
+
+#### 2. シリアルコードの SHA-256 ハッシュを計算
+
+```bash
+# Linux / macOS
+echo -n "YOUR-SERIAL-CODE" | tr '[:lower:]' '[:upper:]' | sha256sum
+# → 64文字の16進数ハッシュが出力される
+
+# Node.js で計算する場合
+node -e "
+const crypto = require('crypto');
+const code = 'YOUR-SERIAL-CODE'.trim().toUpperCase();
+console.log(crypto.createHash('sha256').update(code).digest('hex'));
+"
+```
+
+> **ポイント**: コードは `trim().toUpperCase()` で正規化される。
+> 大文字小文字・前後の空白は区別しない。
+
+#### 3. `UNLOCKABLE_SOUNDS` にエントリを追加
+
+`src/lib/serial-codes.ts`:
+
+```typescript
+export const UNLOCKABLE_SOUNDS: UnlockableSound[] = [
+  {
+    id: "inari-morning-call",          // ユニークID（ストア保存キーになる）
+    label: "おはよういなり",             // UIに表示される名前
+    soundUri: "sounds/morning.mp3",    // バンドルされた音声ファイルのパス
+    codeHash: "abc123...（64文字）",    // 手順2で計算したハッシュ
+  },
+];
+```
+
+#### 4. 動作確認
+
+- アプリの「設定」タブでシリアルコードを入力
+- 「解放済み音声」リストに追加されることを確認
+- アラーム追加ダイアログの音声ドロップダウンに表示されることを確認
+- アプリ再起動後もアンロック状態が維持されることを確認
+
+### 別ライバーのアプリを作る場合
+
+このシステムはそのまま流用できる。変更が必要な箇所のみ：
+
+1. **`UNLOCKABLE_SOUNDS`** (`src/lib/serial-codes.ts`) — ライバー専用音声とコードを定義
+2. **`src-tauri/sounds/`** — 音声ファイルを配置
+3. **アプリ名・識別子** (`src-tauri/tauri.conf.json`) — `productName` と `identifier` を変更
+
+フック・ロジック・UIは変更不要。
+
+### 関連ファイル
+
+```
+src/
+  lib/
+    serial-codes.ts              # UnlockableSound型・UNLOCKABLE_SOUNDS・ハッシュ関数
+    __tests__/
+      serial-codes.test.ts       # ハッシュ関数のユニットテスト
+  hooks/
+    use-unlocked-sounds.ts       # アンロック状態管理フック
+    __mocks__/
+      tauri-plugin-store.ts      # テスト用storeモック
+    __tests__/
+      use-unlocked-sounds.test.ts
+  components/
+    settings/
+      settings-tab.tsx           # シリアルコード入力UI
+    alerm/
+      form.tsx                   # 音声選択ドロップダウン
+src-tauri/
+  sounds/                        # バンドルする音声ファイルを配置
+  Cargo.toml                     # tauri-plugin-store = "2"
+  capabilities/
+    android.json                 # store:allow-* 権限
+    default.json                 # store:allow-* 権限
+  tauri.conf.json                # bundle.resources に sounds/* を設定
+```

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tailwindcss/vite": "^4.2.1",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-store": "^2.4.2",
     "@types/node": "^25.3.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.3
+      '@tauri-apps/plugin-store':
+        specifier: ^2.4.2
+        version: 2.4.2
       '@types/node':
         specifier: ^25.3.2
         version: 25.3.2
@@ -1650,6 +1653,9 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
+
+  '@tauri-apps/plugin-store@2.4.2':
+    resolution: {integrity: sha512-0ClHS50Oq9HEvLPhNzTNFxbWVOqoAp3dRvtewQBeqfIQ0z5m3JRnOISIn2ZVPCrQC0MyGyhTS9DWhHjpigQE7A==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5007,6 +5013,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.10.0
 
   '@tauri-apps/plugin-opener@2.5.3':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-store@2.4.2':
     dependencies:
       '@tauri-apps/api': 2.10.1
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2748,6 +2748,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-alerm",
  "tauri-plugin-opener",
+ "tauri-plugin-store",
 ]
 
 [[package]]
@@ -3660,6 +3661,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-store"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca1a8ff83c269b115e98726ffc13f9e548a10161544a92ad121d6d0a96e16ea"
+dependencies = [
+ "dunce",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3876,7 +3893,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-alerm = { git = "https://github.com/UtakataKyosui/tauri-plugin-alerm-android", rev = "7bef6d41bced216934d5ec8f7c08af7358b01779" }
+tauri-plugin-store = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/capabilities/android.json
+++ b/src-tauri/capabilities/android.json
@@ -7,6 +7,9 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "store:allow-load",
+    "store:allow-get",
+    "store:allow-set",
     "alerm:allow-set-alarm",
     "alerm:allow-cancel-alarm",
     "alerm:allow-list-alarms",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,9 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "store:allow-load",
+    "store:allow-get",
+    "store:allow-set"
   ]
 }

--- a/src-tauri/sounds/README.md
+++ b/src-tauri/sounds/README.md
@@ -1,0 +1,3 @@
+このディレクトリにアンロック可能な音声ファイルを配置する。
+
+音声ファイルを追加したら `src/lib/serial-codes.ts` の `UNLOCKABLE_SOUNDS` にエントリを追加すること。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ fn greet(name: &str) -> String {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_alerm::init())
         .invoke_handler(tauri::generate_handler![greet])
         .run(tauri::generate_context!())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,6 +24,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": {
+      "sounds/*": "sounds/"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,53 +2,25 @@ import "./App.css";
 
 import Navbar from "./components/common/navbar";
 import AlermList from "./components/alerm/list";
-
+import SettingsTab from "./components/settings/settings-tab";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 
 function App() {
-  // const [greetMsg, setGreetMsg] = useState("");
-  // const [name, setName] = useState("");
-
-  // async function greet() {
-  //   // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-  //   setGreetMsg(await invoke("greet", { name }));
-  // }
-
   return (
-    // <main className="container">
-    //   <h1>Welcome to Tauri + React</h1>
-
-    //   <div className="row">
-    //     <a href="https://vite.dev" target="_blank">
-    //       <img src="/vite.svg" className="logo vite" alt="Vite logo" />
-    //     </a>
-    //     <a href="https://tauri.app" target="_blank">
-    //       <img src="/tauri.svg" className="logo tauri" alt="Tauri logo" />
-    //     </a>
-    //     <a href="https://react.dev" target="_blank">
-    //       <img src={reactLogo} className="logo react" alt="React logo" />
-    //     </a>
-    //   </div>
-    //   <p>Click on the Tauri, Vite, and React logos to learn more.</p>
-
-    //   <form
-    //     className="row"
-    //     onSubmit={(e) => {
-    //       e.preventDefault();
-    //       greet();
-    //     }}
-    //   >
-    //     <input
-    //       id="greet-input"
-    //       onChange={(e) => setName(e.currentTarget.value)}
-    //       placeholder="Enter a name..."
-    //     />
-    //     <button type="submit">Greet</button>
-    //   </form>
-    //   <p>{greetMsg}</p>
-    // </main>
     <main className="container mx-auto py-8 h-screen">
       <Navbar />
-      <AlermList />
+      <Tabs defaultValue="alarm" className="mt-4">
+        <TabsList>
+          <TabsTrigger value="alarm">アラーム</TabsTrigger>
+          <TabsTrigger value="settings">設定</TabsTrigger>
+        </TabsList>
+        <TabsContent value="alarm">
+          <AlermList />
+        </TabsContent>
+        <TabsContent value="settings">
+          <SettingsTab />
+        </TabsContent>
+      </Tabs>
     </main>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,11 @@ import Navbar from "./components/common/navbar";
 import AlermList from "./components/alerm/list";
 import SettingsTab from "./components/settings/settings-tab";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { useUnlockedSounds } from "@/hooks/use-unlocked-sounds";
 
 function App() {
+  const { unlockedSounds, isLoading, unlockByCode } = useUnlockedSounds();
+
   return (
     <main className="container mx-auto py-8 h-screen">
       <Navbar />
@@ -15,10 +18,14 @@ function App() {
           <TabsTrigger value="settings">設定</TabsTrigger>
         </TabsList>
         <TabsContent value="alarm">
-          <AlermList />
+          <AlermList unlockedSounds={unlockedSounds} />
         </TabsContent>
         <TabsContent value="settings">
-          <SettingsTab />
+          <SettingsTab
+            unlockedSounds={unlockedSounds}
+            soundsLoading={isLoading}
+            unlockByCode={unlockByCode}
+          />
         </TabsContent>
       </Tabs>
     </main>

--- a/src/components/alerm/form.tsx
+++ b/src/components/alerm/form.tsx
@@ -24,6 +24,13 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Calendar } from "@/components/ui/calendar";
 import {
   Popover,
@@ -32,6 +39,7 @@ import {
 } from "@/components/ui/popover";
 import { SetAlarmOptions } from "@/hooks/use-alerm";
 import { toast } from "sonner";
+import { type UnlockableSound } from "@/lib/serial-codes";
 
 export const alermFormSchema = z.object({
   title: z.string().min(1, "タイトルは必須です").max(50, "50文字以内で入力してください"),
@@ -53,9 +61,10 @@ export type AlermFormData = z.infer<typeof alermFormSchema>;
 
 interface AlermFormProps {
   onSubmit: (options: SetAlarmOptions) => Promise<void>;
+  unlockedSounds: UnlockableSound[];
 }
 
-export function AlermForm({ onSubmit }: AlermFormProps) {
+export function AlermForm({ onSubmit, unlockedSounds }: AlermFormProps) {
   const [open, setOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -258,16 +267,33 @@ export function AlermForm({ onSubmit }: AlermFormProps) {
               name="soundUri"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>アラーム音（オプション）</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder="sounds/alarm.mp3"
-                      {...field}
-                      value={field.value ?? ""}
-                    />
-                  </FormControl>
+                  <FormLabel>アラーム音</FormLabel>
+                  <Select
+                    onValueChange={(value) =>
+                      field.onChange(value === "__system__" ? undefined : value)
+                    }
+                    defaultValue="__system__"
+                  >
+                    <FormControl>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="システム音（デフォルト）" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="__system__">
+                        システム音（デフォルト）
+                      </SelectItem>
+                      {unlockedSounds.map((sound) => (
+                        <SelectItem key={sound.id} value={sound.soundUri}>
+                          {sound.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                   <FormDescription>
-                    アセットフォルダ内の音声ファイルパス（省略時はシステム音）
+                    {unlockedSounds.length === 0
+                      ? "設定タブでシリアルコードを入力すると特別な音声が選べるで"
+                      : "解放済みの音声から選択できるで"}
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/src/components/alerm/form.tsx
+++ b/src/components/alerm/form.tsx
@@ -272,7 +272,7 @@ export function AlermForm({ onSubmit, unlockedSounds }: AlermFormProps) {
                     onValueChange={(value) =>
                       field.onChange(value === "__system__" ? undefined : value)
                     }
-                    defaultValue="__system__"
+                    value={field.value ?? "__system__"}
                   >
                     <FormControl>
                       <SelectTrigger className="w-full">

--- a/src/components/alerm/list.tsx
+++ b/src/components/alerm/list.tsx
@@ -1,13 +1,17 @@
 import { BellOffIcon } from "lucide-react";
 import { useAlerm } from "@/hooks/use-alerm";
-import { useUnlockedSounds } from "@/hooks/use-unlocked-sounds";
+import { type UnlockableSound } from "@/lib/serial-codes";
 import { Spinner } from "@/components/ui/spinner";
 import { ItemGroup } from "@/components/ui/item";
 import { PermissionBanner } from "./permission-banner";
 import { AlermForm } from "./form";
 import { AlarmCard } from "./alarm-card";
 
-export default function AlermList() {
+interface AlermListProps {
+  unlockedSounds: UnlockableSound[];
+}
+
+export default function AlermList({ unlockedSounds }: AlermListProps) {
   const {
     alarms,
     isLoading,
@@ -17,7 +21,6 @@ export default function AlermList() {
     removeAlarm,
     openPermissionSettings,
   } = useAlerm();
-  const { unlockedSounds } = useUnlockedSounds();
 
   if (isLoading) {
     return (

--- a/src/components/alerm/list.tsx
+++ b/src/components/alerm/list.tsx
@@ -1,5 +1,6 @@
 import { BellOffIcon } from "lucide-react";
 import { useAlerm } from "@/hooks/use-alerm";
+import { useUnlockedSounds } from "@/hooks/use-unlocked-sounds";
 import { Spinner } from "@/components/ui/spinner";
 import { ItemGroup } from "@/components/ui/item";
 import { PermissionBanner } from "./permission-banner";
@@ -16,6 +17,7 @@ export default function AlermList() {
     removeAlarm,
     openPermissionSettings,
   } = useAlerm();
+  const { unlockedSounds } = useUnlockedSounds();
 
   if (isLoading) {
     return (
@@ -32,7 +34,7 @@ export default function AlermList() {
         onOpenSettings={openPermissionSettings}
       />
 
-      <AlermForm onSubmit={addAlarm} />
+      <AlermForm onSubmit={addAlarm} unlockedSounds={unlockedSounds} />
 
       {alarms.length === 0 ? (
         <div className="text-center py-12">

--- a/src/components/settings/settings-tab.tsx
+++ b/src/components/settings/settings-tab.tsx
@@ -28,13 +28,16 @@ export default function SettingsTab() {
       } else {
         toast.error("無効なシリアルコードやで");
       }
+    } catch (error) {
+      console.error("音声の解放に失敗しました:", error);
+      toast.error("音声の解放に失敗しました。しばらくしてからもう一度試してな");
     } finally {
       setIsLoading(false);
       inputRef.current?.focus();
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: { key: string }) => {
     if (e.key === "Enter") {
       handleUnlock();
     }

--- a/src/components/settings/settings-tab.tsx
+++ b/src/components/settings/settings-tab.tsx
@@ -1,21 +1,31 @@
-import { useState, useRef } from "react";
+import { useState, useRef, type KeyboardEvent } from "react";
 import { KeyRoundIcon, Volume2Icon, CheckCircleIcon } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
-import { useUnlockedSounds } from "@/hooks/use-unlocked-sounds";
+import { type UnlockableSound } from "@/lib/serial-codes";
+import { type UnlockResult } from "@/hooks/use-unlocked-sounds";
 
-export default function SettingsTab() {
+interface SettingsTabProps {
+  unlockedSounds: UnlockableSound[];
+  soundsLoading: boolean;
+  unlockByCode: (code: string) => Promise<UnlockResult>;
+}
+
+export default function SettingsTab({
+  unlockedSounds,
+  soundsLoading,
+  unlockByCode,
+}: SettingsTabProps) {
   const [code, setCode] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const { unlockedSounds, unlockByCode } = useUnlockedSounds();
 
   const handleUnlock = async () => {
     const trimmed = code.trim();
     if (!trimmed) return;
 
-    setIsLoading(true);
+    setIsSubmitting(true);
     try {
       const result = await unlockByCode(trimmed);
       if (result.success) {
@@ -32,16 +42,18 @@ export default function SettingsTab() {
       console.error("音声の解放に失敗しました:", error);
       toast.error("音声の解放に失敗しました。しばらくしてからもう一度試してな");
     } finally {
-      setIsLoading(false);
+      setIsSubmitting(false);
       inputRef.current?.focus();
     }
   };
 
-  const handleKeyDown = (e: { key: string }) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       handleUnlock();
     }
   };
+
+  const isDisabled = isSubmitting || soundsLoading;
 
   return (
     <div className="space-y-6">
@@ -61,10 +73,10 @@ export default function SettingsTab() {
             onKeyDown={handleKeyDown}
             placeholder="シリアルコードを入力"
             className="flex-1"
-            disabled={isLoading}
+            disabled={isDisabled}
           />
-          <Button onClick={handleUnlock} disabled={isLoading || !code.trim()}>
-            {isLoading ? "確認中..." : "解放する"}
+          <Button onClick={handleUnlock} disabled={isDisabled || !code.trim()}>
+            {isSubmitting ? "確認中..." : "解放する"}
           </Button>
         </div>
       </section>

--- a/src/components/settings/settings-tab.tsx
+++ b/src/components/settings/settings-tab.tsx
@@ -1,0 +1,94 @@
+import { useState, useRef } from "react";
+import { KeyRoundIcon, Volume2Icon, CheckCircleIcon } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { useUnlockedSounds } from "@/hooks/use-unlocked-sounds";
+
+export default function SettingsTab() {
+  const [code, setCode] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { unlockedSounds, unlockByCode } = useUnlockedSounds();
+
+  const handleUnlock = async () => {
+    const trimmed = code.trim();
+    if (!trimmed) return;
+
+    setIsLoading(true);
+    try {
+      const result = await unlockByCode(trimmed);
+      if (result.success) {
+        if (result.alreadyUnlocked) {
+          toast.info(`「${result.sound.label}」はすでに解放済みやで`);
+        } else {
+          toast.success(`「${result.sound.label}」を解放したで！`);
+          setCode("");
+        }
+      } else {
+        toast.error("無効なシリアルコードやで");
+      }
+    } finally {
+      setIsLoading(false);
+      inputRef.current?.focus();
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleUnlock();
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <KeyRoundIcon className="w-5 h-5 text-muted-foreground" />
+          <h2 className="text-base font-semibold">シリアルコードで音声を解放</h2>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          シリアルコードを入力すると、特別な音声をアンロックできるで
+        </p>
+        <div className="flex gap-2">
+          <Input
+            ref={inputRef}
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="シリアルコードを入力"
+            className="flex-1"
+            disabled={isLoading}
+          />
+          <Button onClick={handleUnlock} disabled={isLoading || !code.trim()}>
+            {isLoading ? "確認中..." : "解放する"}
+          </Button>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Volume2Icon className="w-5 h-5 text-muted-foreground" />
+          <h2 className="text-base font-semibold">解放済み音声</h2>
+        </div>
+        {unlockedSounds.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-4 text-center">
+            まだ音声が解放されていません
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {unlockedSounds.map((sound) => (
+              <li
+                key={sound.id}
+                className="flex items-center gap-3 rounded-md border px-3 py-2"
+              >
+                <CheckCircleIcon className="w-4 h-4 text-green-500 shrink-0" />
+                <span className="text-sm">{sound.label}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/hooks/__mocks__/tauri-plugin-store.ts
+++ b/src/hooks/__mocks__/tauri-plugin-store.ts
@@ -1,0 +1,30 @@
+import { vi } from "vitest";
+
+export interface MockStore {
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+}
+
+let mockStoreData: Record<string, unknown> = {};
+
+const createMockStore = (): MockStore => ({
+  get: vi.fn((key: string) => Promise.resolve(mockStoreData[key] ?? null)),
+  set: vi.fn((key: string, value: unknown) => {
+    mockStoreData[key] = value;
+    return Promise.resolve();
+  }),
+});
+
+let currentMockStore: MockStore = createMockStore();
+
+export const load = vi.fn(() => Promise.resolve(currentMockStore));
+
+export function resetMockStore(initialData: Record<string, unknown> = {}) {
+  mockStoreData = { ...initialData };
+  currentMockStore = createMockStore();
+  load.mockImplementation(() => Promise.resolve(currentMockStore));
+}
+
+export function getMockStore(): MockStore {
+  return currentMockStore;
+}

--- a/src/hooks/__mocks__/tauri-plugin-store.ts
+++ b/src/hooks/__mocks__/tauri-plugin-store.ts
@@ -3,6 +3,7 @@ import { vi } from "vitest";
 export interface MockStore {
   get: ReturnType<typeof vi.fn>;
   set: ReturnType<typeof vi.fn>;
+  save: ReturnType<typeof vi.fn>;
 }
 
 let mockStoreData: Record<string, unknown> = {};
@@ -13,6 +14,7 @@ const createMockStore = (): MockStore => ({
     mockStoreData[key] = value;
     return Promise.resolve();
   }),
+  save: vi.fn(() => Promise.resolve()),
 });
 
 let currentMockStore: MockStore = createMockStore();

--- a/src/hooks/__tests__/use-unlocked-sounds.test.ts
+++ b/src/hooks/__tests__/use-unlocked-sounds.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useUnlockedSounds } from "../use-unlocked-sounds";
+import { UNLOCKABLE_SOUNDS, hashSerialCode } from "../../lib/serial-codes";
+import { resetMockStore, getMockStore } from "../__mocks__/tauri-plugin-store";
+
+// vite.config.ts の test.alias で @tauri-apps/plugin-store → モックファイルに解決済み
+
+const TEST_CODE = "TEST-UNLOCK-CODE-9999";
+let testCodeHash: string;
+let testSoundEntry: { id: string; label: string; soundUri: string; codeHash: string };
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  resetMockStore();
+
+  testCodeHash = await hashSerialCode(TEST_CODE);
+  testSoundEntry = {
+    id: "test-sound-1",
+    label: "テスト音声",
+    soundUri: "sounds/test.mp3",
+    codeHash: testCodeHash,
+  };
+
+  // テスト用に UNLOCKABLE_SOUNDS に追加
+  UNLOCKABLE_SOUNDS.push(testSoundEntry);
+});
+
+afterEach(() => {
+  // テスト後に追加したエントリを削除
+  const idx = UNLOCKABLE_SOUNDS.indexOf(testSoundEntry);
+  if (idx !== -1) {
+    UNLOCKABLE_SOUNDS.splice(idx, 1);
+  }
+});
+
+describe("useUnlockedSounds", () => {
+  it("初期化: ストアが空のとき unlockedSounds は空配列", async () => {
+    const { result } = renderHook(() => useUnlockedSounds());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.unlockedSounds).toEqual([]);
+  });
+
+  it("初期化: ストアに保存済みIDがある場合、対応する音声が復元される", async () => {
+    resetMockStore({ unlocked_sounds: ["test-sound-1"] });
+
+    const { result } = renderHook(() => useUnlockedSounds());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.unlockedSounds).toHaveLength(1);
+    expect(result.current.unlockedSounds[0].id).toBe("test-sound-1");
+  });
+
+  it("unlockByCode: 無効なコードは { success: false, reason: 'invalid_code' } を返す", async () => {
+    const { result } = renderHook(() => useUnlockedSounds());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    let unlockResult: Awaited<ReturnType<typeof result.current.unlockByCode>>;
+    await act(async () => {
+      unlockResult = await result.current.unlockByCode("INVALID-CODE-XXXX");
+    });
+
+    expect(unlockResult!).toEqual({ success: false, reason: "invalid_code" });
+  });
+
+  it("unlockByCode: 有効なコードで音声がアンロックされストアに保存される", async () => {
+    const { result } = renderHook(() => useUnlockedSounds());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    let unlockResult: Awaited<ReturnType<typeof result.current.unlockByCode>>;
+    await act(async () => {
+      unlockResult = await result.current.unlockByCode(TEST_CODE);
+    });
+
+    expect(unlockResult!.success).toBe(true);
+    if (unlockResult!.success) {
+      expect(unlockResult!.sound.id).toBe("test-sound-1");
+      expect(unlockResult!.alreadyUnlocked).toBe(false);
+    }
+
+    expect(result.current.unlockedSounds).toHaveLength(1);
+    expect(result.current.unlockedSounds[0].id).toBe("test-sound-1");
+
+    const store = getMockStore();
+    expect(store.set).toHaveBeenCalledWith("unlocked_sounds", ["test-sound-1"]);
+  });
+
+  it("unlockByCode: 既解放済みのコードは alreadyUnlocked: true でストアへの再書き込みなし", async () => {
+    resetMockStore({ unlocked_sounds: ["test-sound-1"] });
+
+    const { result } = renderHook(() => useUnlockedSounds());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const store = getMockStore();
+    store.set.mockClear();
+
+    let unlockResult: Awaited<ReturnType<typeof result.current.unlockByCode>>;
+    await act(async () => {
+      unlockResult = await result.current.unlockByCode(TEST_CODE);
+    });
+
+    expect(unlockResult!.success).toBe(true);
+    if (unlockResult!.success) {
+      expect(unlockResult!.alreadyUnlocked).toBe(true);
+    }
+
+    expect(store.set).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/use-unlocked-sounds.test.ts
+++ b/src/hooks/__tests__/use-unlocked-sounds.test.ts
@@ -85,17 +85,18 @@ describe("useUnlockedSounds", () => {
       unlockResult = await result.current.unlockByCode(TEST_CODE);
     });
 
-    expect(unlockResult!.success).toBe(true);
-    if (unlockResult!.success) {
-      expect(unlockResult!.sound.id).toBe("test-sound-1");
-      expect(unlockResult!.alreadyUnlocked).toBe(false);
-    }
+    expect(unlockResult!).toEqual({
+      success: true,
+      sound: testSoundEntry,
+      alreadyUnlocked: false,
+    });
 
     expect(result.current.unlockedSounds).toHaveLength(1);
     expect(result.current.unlockedSounds[0].id).toBe("test-sound-1");
 
     const store = getMockStore();
     expect(store.set).toHaveBeenCalledWith("unlocked_sounds", ["test-sound-1"]);
+    expect(store.save).toHaveBeenCalled();
   });
 
   it("unlockByCode: 既解放済みのコードは alreadyUnlocked: true でストアへの再書き込みなし", async () => {
@@ -115,10 +116,11 @@ describe("useUnlockedSounds", () => {
       unlockResult = await result.current.unlockByCode(TEST_CODE);
     });
 
-    expect(unlockResult!.success).toBe(true);
-    if (unlockResult!.success) {
-      expect(unlockResult!.alreadyUnlocked).toBe(true);
-    }
+    expect(unlockResult!).toEqual({
+      success: true,
+      sound: testSoundEntry,
+      alreadyUnlocked: true,
+    });
 
     expect(store.set).not.toHaveBeenCalled();
   });

--- a/src/hooks/use-unlocked-sounds.ts
+++ b/src/hooks/use-unlocked-sounds.ts
@@ -20,24 +20,38 @@ export function useUnlockedSounds(): {
   const [unlockedSounds, setUnlockedSounds] = useState<UnlockableSound[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const storeRef = useRef<Store | null>(null);
+  // stale closureを避けるために最新の状態をrefでも保持する
+  const unlockedRef = useRef<UnlockableSound[]>([]);
+
+  function syncUnlocked(value: UnlockableSound[]) {
+    unlockedRef.current = value;
+    setUnlockedSounds(value);
+  }
 
   useEffect(() => {
     let cancelled = false;
 
     async function init() {
-      const store = await load("unlocked-sounds.json");
-      if (cancelled) return;
-      storeRef.current = store;
+      try {
+        const store = await load("unlocked-sounds.json");
+        if (cancelled) return;
+        storeRef.current = store;
 
-      const savedIds = (await store.get<string[]>(STORE_KEY)) ?? [];
-      if (cancelled) return;
+        const savedIds = (await store.get<string[]>(STORE_KEY)) ?? [];
+        if (cancelled) return;
 
-      const restored = savedIds
-        .map((id) => UNLOCKABLE_SOUNDS.find((s) => s.id === id))
-        .filter((s): s is UnlockableSound => s !== undefined);
+        const restored = savedIds
+          .map((id) => UNLOCKABLE_SOUNDS.find((s) => s.id === id))
+          .filter((s): s is UnlockableSound => s !== undefined);
 
-      setUnlockedSounds(restored);
-      setIsLoading(false);
+        syncUnlocked(restored);
+      } catch (error) {
+        console.error("Failed to initialize unlocked sounds from store:", error);
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
     }
 
     init();
@@ -52,19 +66,26 @@ export function useUnlockedSounds(): {
       return { success: false, reason: "invalid_code" };
     }
 
-    const alreadyUnlocked = unlockedSounds.some((s) => s.id === sound.id);
+    const current = unlockedRef.current;
+    const alreadyUnlocked = current.some((s) => s.id === sound.id);
     if (alreadyUnlocked) {
       return { success: true, sound, alreadyUnlocked: true };
     }
 
-    const newUnlocked = [...unlockedSounds, sound];
-    setUnlockedSounds(newUnlocked);
+    const newUnlocked = [...current, sound];
+    syncUnlocked(newUnlocked);
 
     if (storeRef.current) {
-      await storeRef.current.set(
-        STORE_KEY,
-        newUnlocked.map((s) => s.id)
-      );
+      try {
+        await storeRef.current.set(
+          STORE_KEY,
+          newUnlocked.map((s) => s.id)
+        );
+      } catch (e) {
+        // 永続化失敗時はUIをロールバックしてエラーを再スロー
+        syncUnlocked(current);
+        throw e;
+      }
     }
 
     return { success: true, sound, alreadyUnlocked: false };

--- a/src/hooks/use-unlocked-sounds.ts
+++ b/src/hooks/use-unlocked-sounds.ts
@@ -81,6 +81,7 @@ export function useUnlockedSounds(): {
           STORE_KEY,
           newUnlocked.map((s) => s.id)
         );
+        await storeRef.current.save();
       } catch (e) {
         // 永続化失敗時はUIをロールバックしてエラーを再スロー
         syncUnlocked(current);

--- a/src/hooks/use-unlocked-sounds.ts
+++ b/src/hooks/use-unlocked-sounds.ts
@@ -1,0 +1,74 @@
+import { useState, useEffect, useRef } from "react";
+import { load, type Store } from "@tauri-apps/plugin-store";
+import {
+  findSoundByCode,
+  UNLOCKABLE_SOUNDS,
+  type UnlockableSound,
+} from "../lib/serial-codes";
+
+const STORE_KEY = "unlocked_sounds";
+
+export type UnlockResult =
+  | { success: true; sound: UnlockableSound; alreadyUnlocked: boolean }
+  | { success: false; reason: "invalid_code" };
+
+export function useUnlockedSounds(): {
+  unlockedSounds: UnlockableSound[];
+  isLoading: boolean;
+  unlockByCode: (code: string) => Promise<UnlockResult>;
+} {
+  const [unlockedSounds, setUnlockedSounds] = useState<UnlockableSound[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const storeRef = useRef<Store | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function init() {
+      const store = await load("unlocked-sounds.json");
+      if (cancelled) return;
+      storeRef.current = store;
+
+      const savedIds = (await store.get<string[]>(STORE_KEY)) ?? [];
+      if (cancelled) return;
+
+      const restored = savedIds
+        .map((id) => UNLOCKABLE_SOUNDS.find((s) => s.id === id))
+        .filter((s): s is UnlockableSound => s !== undefined);
+
+      setUnlockedSounds(restored);
+      setIsLoading(false);
+    }
+
+    init();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function unlockByCode(code: string): Promise<UnlockResult> {
+    const sound = await findSoundByCode(code);
+    if (!sound) {
+      return { success: false, reason: "invalid_code" };
+    }
+
+    const alreadyUnlocked = unlockedSounds.some((s) => s.id === sound.id);
+    if (alreadyUnlocked) {
+      return { success: true, sound, alreadyUnlocked: true };
+    }
+
+    const newUnlocked = [...unlockedSounds, sound];
+    setUnlockedSounds(newUnlocked);
+
+    if (storeRef.current) {
+      await storeRef.current.set(
+        STORE_KEY,
+        newUnlocked.map((s) => s.id)
+      );
+    }
+
+    return { success: true, sound, alreadyUnlocked: false };
+  }
+
+  return { unlockedSounds, isLoading, unlockByCode };
+}

--- a/src/lib/__tests__/serial-codes.test.ts
+++ b/src/lib/__tests__/serial-codes.test.ts
@@ -45,19 +45,22 @@ describe("findSoundByCode", () => {
   });
 
   it("UNLOCKABLE_SOUNDSにコードがある場合、マッチする音声を返す", async () => {
-    // テスト用の固定ハッシュを計算して確認する
-    // ここではUNLOCKABLE_SOUNDSに実際のデータがある場合のテスト構造を示す
-    // 現時点でUNLOCKABLE_SOUNDSは空なので、動作検証はモックで行う
-    if (UNLOCKABLE_SOUNDS.length === 0) {
-      // 空の場合は必ずnullが返ること
-      const result = await findSoundByCode("ANY-CODE");
-      expect(result).toBeNull();
-    } else {
-      // データがある場合は最初のコードでマッチすることを確認
-      const firstSound = UNLOCKABLE_SOUNDS[0];
-      // コードのハッシュに一致するコードでnullでないことを確認
-      // （実際のコードは埋め込まれていないため、ハッシュ比較でnullになる）
-      expect(firstSound).toBeDefined();
+    const testCode = "TEST-CODE-MATCH-FIND";
+    const codeHash = await hashSerialCode(testCode);
+    const testSound: UnlockableSound = {
+      id: "test-find-id",
+      label: "マッチテスト音声",
+      soundUri: "sounds/test-find.mp3",
+      codeHash,
+    };
+
+    UNLOCKABLE_SOUNDS.push(testSound);
+    try {
+      const result = await findSoundByCode(testCode);
+      expect(result).toEqual(testSound);
+    } finally {
+      const idx = UNLOCKABLE_SOUNDS.indexOf(testSound);
+      if (idx !== -1) UNLOCKABLE_SOUNDS.splice(idx, 1);
     }
   });
 

--- a/src/lib/__tests__/serial-codes.test.ts
+++ b/src/lib/__tests__/serial-codes.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  hashSerialCode,
+  findSoundByCode,
+  UNLOCKABLE_SOUNDS,
+  type UnlockableSound,
+} from "../serial-codes";
+
+describe("hashSerialCode", () => {
+  it("同じ入力は同じSHA-256ハッシュを返す", async () => {
+    const hash1 = await hashSerialCode("TEST-CODE-1234");
+    const hash2 = await hashSerialCode("TEST-CODE-1234");
+    expect(hash1).toBe(hash2);
+  });
+
+  it("大文字小文字を区別しない（toUpperCase正規化）", async () => {
+    const hashUpper = await hashSerialCode("TEST-CODE-1234");
+    const hashLower = await hashSerialCode("test-code-1234");
+    expect(hashUpper).toBe(hashLower);
+  });
+
+  it("前後の空白を無視する", async () => {
+    const hashTrimmed = await hashSerialCode("TEST-CODE-1234");
+    const hashWithSpaces = await hashSerialCode("  TEST-CODE-1234  ");
+    expect(hashTrimmed).toBe(hashWithSpaces);
+  });
+
+  it("異なる入力は異なるハッシュを返す", async () => {
+    const hash1 = await hashSerialCode("TEST-CODE-1234");
+    const hash2 = await hashSerialCode("TEST-CODE-5678");
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("ハッシュは64文字の16進数文字列", async () => {
+    const hash = await hashSerialCode("TEST-CODE-1234");
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("findSoundByCode", () => {
+  it("UNLOCKABLE_SOUNDSが空の場合、無効なコードはnullを返す", async () => {
+    const result = await findSoundByCode("INVALID-CODE-9999");
+    expect(result).toBeNull();
+  });
+
+  it("UNLOCKABLE_SOUNDSにコードがある場合、マッチする音声を返す", async () => {
+    // テスト用の固定ハッシュを計算して確認する
+    // ここではUNLOCKABLE_SOUNDSに実際のデータがある場合のテスト構造を示す
+    // 現時点でUNLOCKABLE_SOUNDSは空なので、動作検証はモックで行う
+    if (UNLOCKABLE_SOUNDS.length === 0) {
+      // 空の場合は必ずnullが返ること
+      const result = await findSoundByCode("ANY-CODE");
+      expect(result).toBeNull();
+    } else {
+      // データがある場合は最初のコードでマッチすることを確認
+      const firstSound = UNLOCKABLE_SOUNDS[0];
+      // コードのハッシュに一致するコードでnullでないことを確認
+      // （実際のコードは埋め込まれていないため、ハッシュ比較でnullになる）
+      expect(firstSound).toBeDefined();
+    }
+  });
+
+  it("大文字小文字を区別しないコード検索", async () => {
+    const resultUpper = await findSoundByCode("TEST-UPPER");
+    const resultLower = await findSoundByCode("test-upper");
+    // 両方とも同じ結果になる（現時点ではどちらもnull）
+    expect(resultUpper).toBe(resultLower);
+  });
+
+  it("前後に空白があっても同じ結果を返す", async () => {
+    const resultNormal = await findSoundByCode("TEST-CODE");
+    const resultSpaced = await findSoundByCode("  TEST-CODE  ");
+    expect(resultNormal).toBe(resultSpaced);
+  });
+});
+
+describe("UNLOCKABLE_SOUNDS", () => {
+  it("配列として定義されている", () => {
+    expect(Array.isArray(UNLOCKABLE_SOUNDS)).toBe(true);
+  });
+
+  it("各要素は正しい構造を持つ", () => {
+    UNLOCKABLE_SOUNDS.forEach((sound: UnlockableSound) => {
+      expect(sound).toHaveProperty("id");
+      expect(sound).toHaveProperty("label");
+      expect(sound).toHaveProperty("soundUri");
+      expect(sound).toHaveProperty("codeHash");
+      expect(typeof sound.id).toBe("string");
+      expect(typeof sound.label).toBe("string");
+      expect(typeof sound.soundUri).toBe("string");
+      expect(typeof sound.codeHash).toBe("string");
+      // codeHashは64文字の16進数
+      expect(sound.codeHash).toHaveLength(64);
+      expect(sound.codeHash).toMatch(/^[0-9a-f]{64}$/);
+    });
+  });
+});

--- a/src/lib/serial-codes.ts
+++ b/src/lib/serial-codes.ts
@@ -1,0 +1,25 @@
+export interface UnlockableSound {
+  id: string;
+  label: string;
+  soundUri: string;
+  codeHash: string;
+}
+
+// 音声ファイル確定後にここにハッシュを追加する
+export const UNLOCKABLE_SOUNDS: UnlockableSound[] = [];
+
+export async function hashSerialCode(code: string): Promise<string> {
+  const normalized = code.trim().toUpperCase();
+  const encoder = new TextEncoder();
+  const data = encoder.encode(normalized);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export async function findSoundByCode(
+  code: string
+): Promise<UnlockableSound | null> {
+  const hash = await hashSerialCode(code);
+  return UNLOCKABLE_SOUNDS.find((s) => s.codeHash === hash) ?? null;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,7 @@ export default defineConfig(async () => ({
     exclude: [...configDefaults.exclude, "**/.worktrees/**"],
     alias: {
       "tauri-plugin-alerm-api": path.resolve(__dirname, "./src/hooks/__mocks__/tauri-plugin-alerm-api.ts"),
+      "@tauri-apps/plugin-store": path.resolve(__dirname, "./src/hooks/__mocks__/tauri-plugin-store.ts"),
     }
   }
 }));


### PR DESCRIPTION
## Summary

- SHA-256ハッシュによるクライアントサイドのみのシリアルコード検証ロジックを実装
- `tauri-plugin-store` を追加し、アンロック済み音声のIDをアプリ再起動後も永続化
- 設定タブ（`src/components/settings/settings-tab.tsx`）を新規追加し、シリアルコード入力UI・解放済み音声リストを実装
- アラームフォームの `soundUri` フィールドを手動テキスト入力から `Select` ドロップダウンに変更
- `useUnlockedSounds` フックと `serial-codes` ライブラリを TDD（Red→Green）で実装（32テスト全パス）

## Test Plan

- [x] `pnpm test --run` — 32テスト全パス
- [x] `pnpm build` — フロントエンドビルド成功
- [x] `cargo test`（src-tauri内） — Rustテスト成功
- [ ] 実機/エミュレーターで「設定」タブからシリアルコードを入力して音声をアンロック確認
- [ ] アプリ再起動後もアンロック状態が維持されることを確認
- [ ] 「アラーム」タブでアンロック済み音声がドロップダウンに表示されることを確認

## Notes

- `src-tauri/sounds/` ディレクトリは現在空（README.mdのみ）。実際の音声ファイルと対応するSHA-256ハッシュは Step 8 として別途追加予定
- `UNLOCKABLE_SOUNDS` 配列（`src/lib/serial-codes.ts`）は音声ファイル確定後に埋める

🤖 Generated with [Claude Code](https://claude.com/claude-code)